### PR TITLE
feat: Router & Route 컴포넌트 추가

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,8 @@
   "rules": {
     "import/default": "off",
     "import/newline-after-import": "error",
-
+    "import/no-duplicates": "off",
+    
     "prettier/prettier": "error",
     
     "react/react-in-jsx-scope": "off",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,18 @@
 import '@/App.css';
+import About from '@/components/About';
+import Root from '@/components/Root';
+import Route from './components/core/Route';
+import Router from './components/core/Router';
 
 function App() {
-  return <div className="App"></div>;
+  return (
+    <div className="App">
+      <Router>
+        <Route path="/" component={<Root />} />
+        <Route path="/about" component={<About />} />
+      </Router>
+    </div>
+  );
 }
 
 export default App;

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -3,12 +3,15 @@ import { useRouter } from './core/Router';
 export default function About() {
   const { push } = useRouter();
   return (
-    <div
-      onClick={() => {
-        push('/');
-      }}
-    >
-      나? 어바웃
+    <div>
+      <p>나? 어바웃</p>
+      <button
+        onClick={() => {
+          push('/');
+        }}
+      >
+        go main
+      </button>
     </div>
   );
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from './core/Router';
+
+export default function About() {
+  const { push } = useRouter();
+  return (
+    <div
+      onClick={() => {
+        push('/');
+      }}
+    >
+      나? 어바웃
+    </div>
+  );
+}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -3,12 +3,15 @@ import { useRouter } from './core/Router';
 export default function Root() {
   const { push } = useRouter();
   return (
-    <div
-      onClick={() => {
-        push('/about');
-      }}
-    >
-      나? 루트
+    <div>
+      <p>나? 루트</p>
+      <button
+        onClick={() => {
+          push('/about');
+        }}
+      >
+        About
+      </button>
     </div>
   );
 }

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from './core/Router';
+
+export default function Root() {
+  const { push } = useRouter();
+  return (
+    <div
+      onClick={() => {
+        push('/about');
+      }}
+    >
+      나? 루트
+    </div>
+  );
+}

--- a/src/components/core/Route.tsx
+++ b/src/components/core/Route.tsx
@@ -1,0 +1,17 @@
+import { ReactNode, useEffect } from 'react';
+import { useRouter } from './Router';
+
+interface RouteProps {
+  path: string;
+  component: ReactNode;
+}
+
+export default function Route({ path, component }: RouteProps) {
+  const { path: currentPath, action } = useRouter();
+
+  useEffect(() => {
+    action.addRoute(path);
+  }, []);
+
+  return <>{currentPath === path && component}</>;
+}

--- a/src/components/core/Router.tsx
+++ b/src/components/core/Router.tsx
@@ -51,8 +51,8 @@ export default function Router({ children }: { children: ReactElement[] }) {
   );
 
   useEffect(() => {
-    window.onpopstate = (event: PopStateEvent) => {
-      console.log(event);
+    window.onpopstate = () => {
+      actions.setPath(window.location.pathname);
     };
 
     return () => {

--- a/src/components/core/Router.tsx
+++ b/src/components/core/Router.tsx
@@ -1,0 +1,74 @@
+import { createContext, ReactElement, useContext, useEffect, useMemo, useState } from 'react';
+
+interface RouterActions {
+  setPath(path: string): void;
+  addRoute(path: string): void;
+}
+
+const RouterContext = createContext('');
+const RouterActionsContext = createContext<RouterActions | null>(null);
+
+export function useRouter() {
+  const path = useContext(RouterContext);
+  const action = useContext(RouterActionsContext);
+  if (path === undefined) {
+    throw new Error('Router and Route component should be used within RouterContext');
+  }
+  if (!action) {
+    throw new Error('Router and Route component should be used within RouterAction');
+  }
+
+  const push = (path: string) => {
+    action.setPath(path);
+    window.history.pushState({}, '', new URL(`${window.location.origin + path}`));
+  };
+
+  return { path, action, push };
+}
+
+export default function Router({ children }: { children: ReactElement[] }) {
+  const [path, setRouterPath] = useState<string>('');
+  const [pathList, setPathList] = useState<string[]>(['/']);
+  const [isNotFound, setIsNotFound] = useState(false);
+
+  const actions = useMemo<RouterActions>(
+    () => ({
+      setPath(path) {
+        if (!pathList.some((item) => item === path)) {
+          setIsNotFound(true);
+
+          // TODO: error boundry 적용해보기
+          // throw new Error('404 Not Found');
+        }
+        if (isNotFound) setIsNotFound(false);
+        setRouterPath(path);
+      },
+      addRoute(path) {
+        setPathList((prev) => Array.from(new Set([...prev, path])));
+      },
+    }),
+    [isNotFound, pathList],
+  );
+
+  useEffect(() => {
+    window.onpopstate = (event: PopStateEvent) => {
+      console.log(event);
+    };
+
+    return () => {
+      window.onpopstate = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!path && pathList.length === children.length) {
+      actions.setPath(window.location.pathname);
+    }
+  }, [pathList]);
+
+  return (
+    <RouterActionsContext.Provider value={actions}>
+      <RouterContext.Provider value={path}>{isNotFound ? <h2>404입니다만</h2> : children}</RouterContext.Provider>
+    </RouterActionsContext.Provider>
+  );
+}


### PR DESCRIPTION
## Router
- 하위 Route들에게 Path 정보를 공유해서 사용하기 위하여 contextApi를 활용
- 404 처리를 위해 처음 init했을 경우를 고려하여, 모든 Route List에서 마운트된 이후, path를 설정 및 `pathList`에 현재 path가 있는지 확인

## Route
- `Route`는 `Router`의 하위 요소로 props로 받은 path와 일치하면 props로 받은 컴포넌트를 보여줌
- 그러기 위해 props로 받은 path를 contextApi에 등록하여 404를 구별할 수 있도록함

### 사진

- root

<img width="427" alt="image" src="https://user-images.githubusercontent.com/106960496/194410272-d4e0e48e-05af-44d3-bdd2-19337f3e5ade.png">

- about

<img width="427" alt="image" src="https://user-images.githubusercontent.com/106960496/194410319-a7dc94ce-a405-4e5b-9057-93f211e22e39.png">

- 404

<img width="427" alt="image" src="https://user-images.githubusercontent.com/106960496/194410367-c17b07ba-0cd8-4c2d-b455-b77f36db6b30.png">


